### PR TITLE
Fix document and source code comment

### DIFF
--- a/doc/build.creole
+++ b/doc/build.creole
@@ -78,8 +78,8 @@ You can specify any existing kernel version directly like {{{3.2.0}}} instead of
 
 Install the module.
 {{{
-> mkdir -p /lib/module/`uname -r`/kernel/drivers/block/walb
-> cp -p walb.git/module/walb-mod.ko /lib/module/`uname -r`/kernel/drivers/block/walb/
+> mkdir -p /lib/modules/`uname -r`/kernel/drivers/block/walb
+> cp -p walb.git/module/walb-mod.ko /lib/modules/`uname -r`/kernel/drivers/block/walb/
 > depmod `uname -r`
 }}}
 

--- a/doc/build.creole
+++ b/doc/build.creole
@@ -46,7 +46,7 @@ You can specify the following make options:
 
 == Build userland tools
 
-The userland tools in tool/ directory are obsolute.
+The userland tools in tool/ directory are obsolete.
 Use walb-tools written by c++.
 https://github.com/starpos/walb-tools/
 

--- a/tool/util.h
+++ b/tool/util.h
@@ -49,7 +49,7 @@ void copy_uuid(u8* dst, const u8* src);
 bool read_data(int fd, u8* data, size_t size);
 bool write_data(int fd, const u8* data, size_t size);
 
-/* Sector functions (will be obsolute). */
+/* Sector functions (will be obsolete). */
 bool read_sectors_raw(
 	int fd, u8* sectors_buf, u32 sector_size, u64 offset, int n);
 bool read_sector_raw(

--- a/tool/walb_util.c
+++ b/tool/walb_util.c
@@ -440,7 +440,7 @@ bool init_super_sector(
 
 /**
  * Print super sector for debug.
- * This will be obsolute. Use print_super_sector() instead.
+ * This will be obsolete. Use print_super_sector() instead.
  */
 void print_super_sector_raw(const struct walb_super_sector* super_sect)
 {


### PR DESCRIPTION
ドキュメントとソースコードコメントを一部修正してみました。
差し支えなければ、マージをお願いいたします。

各パッチと修正内容は以下の通りです。

- c2a1491 bugfix: invalid kernel module path.
  - doc/build.creole でカーネルモジュールのパスの表記が"/lib/module"と
    なっていましたので、"/lib/modules"へ修正しました。
- 79806c5 bugfix: misspelling of document and source code comment.
  - doc/build.creole と tool/util.h・tool/walb_util.c のコメントで
    "obsolute"の箇所は、文脈上"obsolete"かと思い、修正しました。

以上です。
よろしくお願いいたします。