### PR TITLE
Fix compile error on linux-4.14.

### DIFF
--- a/module/bio_entry.h
+++ b/module/bio_entry.h
@@ -57,7 +57,7 @@ void wait_for_bio_entry(struct bio_entry *bioe, ulong timeoutMs, uint dev_minor)
  * with own pages.
  */
 struct bio* bio_alloc_with_pages(
-	uint sectors, struct block_device *bdev, gfp_t gfp_mask);
+	uint sectors, struct bio *src, gfp_t gfp_mask);
 void bio_put_with_pages(struct bio *bio);
 struct bio* bio_deep_clone(struct bio *bio, gfp_t gfp_mask);
 

--- a/module/bio_util.h
+++ b/module/bio_util.h
@@ -241,8 +241,8 @@ static inline int snprint_bio(char *buf, size_t size, const struct bio *bio)
                 , bio->bi_vcnt
                 , bio->bi_max_vecs
                 , atomic_read(&bio->__bi_cnt)
-		, MAJOR(bio->bi_bdev->bd_dev)
-		, MINOR(bio->bi_bdev->bd_dev));
+		, MAJOR(bio_dev(bio))
+		, MINOR(bio_dev(bio)));
 	SNPRINT_BIO_PROCEED(buf, size, w, s);
 	s = snprint_bvec_iter(buf, size, &bio->bi_iter);
 	SNPRINT_BIO_PROCEED(buf, size, w, s);
@@ -288,8 +288,8 @@ static inline void print_bio_short(const char *prefix, const struct bio *bio)
 	pr_info("%sbio %p pos %" PRIu64 " len %u"
 		" bdev(%d:%d) opf %08x\n"
 		, prefix, bio, (u64)bio_begin_sector(bio), bio_sectors(bio)
-		, MAJOR(bio->bi_bdev->bd_dev)
-		, MINOR(bio->bi_bdev->bd_dev)
+		, MAJOR(bio_dev(bio))
+		, MINOR(bio_dev(bio))
 		, bio->bi_opf);
 }
 

--- a/module/io.c
+++ b/module/io.c
@@ -2861,10 +2861,10 @@ static void io_acct_start(struct bio_wrapper *biow)
 	biow->start_time = jiffies;
 
 	cpu = part_stat_lock();
-	part_round_stats(cpu, part0);
+	part_round_stats(biow->bio->bi_disk->queue, cpu, part0);
 	part_stat_inc(cpu, part0, ios[rw]);
 	part_stat_add(cpu, part0, sectors[rw], biow->len);
-	part_inc_in_flight(part0, rw);
+	part_inc_in_flight(biow->bio->bi_disk->queue, part0, rw);
 	part_stat_unlock();
 
 #ifdef WALB_DEBUG
@@ -2883,8 +2883,8 @@ static void io_acct_end(struct bio_wrapper *biow)
 
 	cpu = part_stat_lock();
 	part_stat_add(cpu, part0, ticks[rw], duration);
-	part_round_stats(cpu, part0);
-	part_dec_in_flight(part0, rw);
+	part_round_stats(biow->bio->bi_disk->queue, cpu, part0);
+	part_dec_in_flight(biow->bio->bi_disk->queue, part0, rw);
 	part_stat_unlock();
 
 	if (io_latency_threshold_ms_ > 0 && duration_ms > io_latency_threshold_ms_) {

--- a/module/io.c
+++ b/module/io.c
@@ -2853,19 +2853,13 @@ static void pack_cache_put(void)
 
 static void io_acct_start(struct bio_wrapper *biow)
 {
-	int cpu;
 	int rw = bio_data_dir(biow->bio);
 	struct walb_dev *wdev = biow->private_data;
 	struct hd_struct *part0 = &wdev->gd->part0;
 
 	biow->start_time = jiffies;
 
-	cpu = part_stat_lock();
-	part_round_stats(biow->bio->bi_disk->queue, cpu, part0);
-	part_stat_inc(cpu, part0, ios[rw]);
-	part_stat_add(cpu, part0, sectors[rw], biow->len);
-	part_inc_in_flight(biow->bio->bi_disk->queue, part0, rw);
-	part_stat_unlock();
+	generic_start_io_acct(biow->bio->bi_disk->queue, rw, biow->len, part0);
 
 #ifdef WALB_DEBUG
 	atomic_inc(&get_iocored_from_wdev(wdev)->n_io_acct);
@@ -2874,18 +2868,14 @@ static void io_acct_start(struct bio_wrapper *biow)
 
 static void io_acct_end(struct bio_wrapper *biow)
 {
-	int cpu;
 	int rw = bio_data_dir(biow->bio);
 	struct walb_dev *wdev = biow->private_data;
 	struct hd_struct *part0 = &wdev->gd->part0;
 	unsigned long duration = jiffies - biow->start_time;
 	unsigned long duration_ms = jiffies_to_msecs(duration);
 
-	cpu = part_stat_lock();
-	part_stat_add(cpu, part0, ticks[rw], duration);
-	part_round_stats(biow->bio->bi_disk->queue, cpu, part0);
-	part_dec_in_flight(biow->bio->bi_disk->queue, part0, rw);
-	part_stat_unlock();
+	generic_end_io_acct(biow->bio->bi_disk->queue, rw, part0,
+			    biow->start_time);
 
 	if (io_latency_threshold_ms_ > 0 && duration_ms > io_latency_threshold_ms_) {
 		char buf[64];

--- a/module/io.c
+++ b/module/io.c
@@ -1228,7 +1228,7 @@ retry_bio:
 	page2 = virt_to_page((unsigned long)lhead + pbs - 1);
 	ASSERT(page == page2);
 #endif
-	bio->bi_bdev = ldev;
+	bio_set_dev(bio, ldev);
 	off_pb = get_offset_of_lsid(lhead->logpack_lsid, ring_buffer_off, ring_buffer_size);
 	off_lb = addr_lb(pbs, off_pb);
 	bio->bi_iter.bi_sector = off_lb;
@@ -1296,7 +1296,7 @@ static struct bio* logpack_create_bio(
 	if (!cbio)
 		return NULL;
 
-	cbio->bi_bdev = ldev;
+	bio_set_dev(cbio, ldev);
 	cbio->bi_iter.bi_sector = addr_lb(pbs, ldev_off_pb) + bio_off_lb;
 	/* cbio->bi_end_io = NULL; */
 	/* cbio->bi_private = NULL; */
@@ -2384,7 +2384,7 @@ static bool submit_flush(struct bio_entry *bioe, struct block_device *bdev)
 	if (!bio)
 		return false;
 
-	bio->bi_bdev = bdev;
+	bio_set_dev(bio, bdev);
 	bio_set_op_attrs(bio, REQ_OP_WRITE, REQ_PREFLUSH);
 
 	init_bio_entry(bioe, bio);
@@ -3203,7 +3203,7 @@ void iocore_log_make_request(struct walb_dev *wdev, struct bio *bio)
 		bio_io_error(bio);
 		return;
 	}
-	bio->bi_bdev = wdev->ldev;
+	bio_set_dev(bio, wdev->ldev);
 	generic_make_request(bio);
 }
 

--- a/module/redo.c
+++ b/module/redo.c
@@ -336,7 +336,7 @@ static struct bio_wrapper* create_log_bio_wrapper_for_redo(
 	biow = alloc_bio_wrapper_inc(wdev, GFP_NOIO);
 	if (!biow) { goto error2; }
 
-	bio->bi_bdev = wdev->ldev;
+	bio_set_dev(bio, wdev->ldev);
 	off_pb = get_offset_of_lsid(lsid, wdev->ring_buffer_off, wdev->ring_buffer_size);
 	WLOG_(wdev, "lsid: %" PRIu64 " off_pb: %" PRIu64 "\n", lsid, off_pb);
 	off_lb = addr_lb(pbs, off_pb);
@@ -392,7 +392,7 @@ static bool prepare_data_bio_for_redo(
 	bio = bio_alloc(GFP_NOIO, 1);
 	if (!bio) { return false; }
 
-	bio->bi_bdev = wdev->ddev;
+	bio_set_dev(bio, wdev->ddev);
 	bio->bi_iter.bi_sector = pos;
 	bio_set_op_attrs(bio, REQ_OP_WRITE, 0);
 	bio->bi_end_io = bio_end_io_for_redo;
@@ -429,7 +429,7 @@ static struct bio_wrapper* create_discard_bio_wrapper_for_redo(
 	biow = alloc_bio_wrapper_inc(wdev, GFP_NOIO);
 	if (!biow) { goto error1; }
 
-	bio->bi_bdev = wdev->ddev;
+	bio_set_dev(bio, wdev->ddev);
 	bio->bi_iter.bi_sector = pos;
 	bio->bi_iter.bi_size = len << 9;
 	bio_set_op_attrs(bio, REQ_OP_DISCARD, 0);

--- a/module/sector_io.c
+++ b/module/sector_io.c
@@ -59,7 +59,7 @@ bool sector_io(
 	off = offset_in_page(buf);
 
 	bio_set_op_attrs(bio, op, op_flags);
-	bio->bi_bdev = bdev;
+	bio_set_dev(bio, bdev);
 	bio->bi_iter.bi_sector = addr_lb(pbs, addr);
 	bio_add_page(bio, page, pbs, off);
 


### PR DESCRIPTION
Linuxカーネルメインラインの4.14でBIO周りの定義が変更されたために、
WalBドライバでその定義を使用していた箇所でコンパイルエラーが発生していました。

メインライン側のカーネルソース同梱ドライバへの修正内容を参考に、WalBドライバへも
同様の修正を行い、コンパイルエラー無いこと、
動作としてはwalb-toolsのscenario0.pyの全シナリオテストがSUCCESSすることを確認しております。

パッチは3つあり、修正内容は以下のとおりです。
いずれもメインラインのコミットに従って同様の修正を行っています。

- 85dcafa bugfix: #2: unable to reference part_inc_in_flight() and part_dec_in_flight().
	- issue #2 の修正です
	- [*1]のコミットでpart_inc_in_flight() and part_dec_in_flight()がカーネルモジュールから参照不可になっており、[*2]のコミットに従ってジェネリックな関数を使用するように修正しています
- 039fc33 reflect the mainliine commit "block: replace bi_bdev with a gendisk pointer and partitions index".
	- [*3]のコミットでbio構造体のbi_bdevメンバをbi_diskへ変更する修正を行っており、同コミット内のドライバ修正内容に従ってWalBドライバ内を修正しています
- de1892d reflect the mainliine commit "block: pass in queue to inflight accounting".
	- [*4]のコミットでpart_round_stats()とpart_inc_in_flight()の定義が変更されており、同コミット内のドライバ修正内容に従ってWalBドライバ内を修正しています

[*1] blk-mq: provide internal in-flight variant
http://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f299b7c

[*2] drbd: use generic io stats accounting functions to simplify io stat accounting
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2448085

[*3] block: replace bi_bdev with a gendisk pointer and partitions index
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=74d4699

[*4] block: pass in queue to inflight accounting
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d62e26b

なお、そもそも4.14はサポート外かと思われ、
どのようにマージされるか(あるいはマージしないか)はお任せいたします。
(まずはmasterではなく"for-4.14"等でブランチを作成し、そちらへのマージされる形でしょうか。)