### PR TITLE
Fix compile error 4.14

### DIFF
--- a/module/bio_entry.h
+++ b/module/bio_entry.h
@@ -57,7 +57,7 @@ void wait_for_bio_entry(struct bio_entry *bioe, ulong timeoutMs, uint dev_minor)
  * with own pages.
  */
 struct bio* bio_alloc_with_pages(
-	uint sectors, struct block_device *bdev, gfp_t gfp_mask);
+	uint sectors, struct bio *src, gfp_t gfp_mask);
 void bio_put_with_pages(struct bio *bio);
 struct bio* bio_deep_clone(struct bio *bio, gfp_t gfp_mask);
 

--- a/module/bio_util.h
+++ b/module/bio_util.h
@@ -241,8 +241,8 @@ static inline int snprint_bio(char *buf, size_t size, const struct bio *bio)
                 , bio->bi_vcnt
                 , bio->bi_max_vecs
                 , atomic_read(&bio->__bi_cnt)
-		, MAJOR(bio->bi_bdev->bd_dev)
-		, MINOR(bio->bi_bdev->bd_dev));
+		, MAJOR(bio_dev(bio))
+		, MINOR(bio_dev(bio)));
 	SNPRINT_BIO_PROCEED(buf, size, w, s);
 	s = snprint_bvec_iter(buf, size, &bio->bi_iter);
 	SNPRINT_BIO_PROCEED(buf, size, w, s);
@@ -288,8 +288,8 @@ static inline void print_bio_short(const char *prefix, const struct bio *bio)
 	pr_info("%sbio %p pos %" PRIu64 " len %u"
 		" bdev(%d:%d) opf %08x\n"
 		, prefix, bio, (u64)bio_begin_sector(bio), bio_sectors(bio)
-		, MAJOR(bio->bi_bdev->bd_dev)
-		, MINOR(bio->bi_bdev->bd_dev)
+		, MAJOR(bio_dev(bio))
+		, MINOR(bio_dev(bio))
 		, bio->bi_opf);
 }
 

--- a/module/io.c
+++ b/module/io.c
@@ -1228,7 +1228,7 @@ retry_bio:
 	page2 = virt_to_page((unsigned long)lhead + pbs - 1);
 	ASSERT(page == page2);
 #endif
-	bio->bi_bdev = ldev;
+	bio_set_dev(bio, ldev);
 	off_pb = get_offset_of_lsid(lhead->logpack_lsid, ring_buffer_off, ring_buffer_size);
 	off_lb = addr_lb(pbs, off_pb);
 	bio->bi_iter.bi_sector = off_lb;
@@ -1296,7 +1296,7 @@ static struct bio* logpack_create_bio(
 	if (!cbio)
 		return NULL;
 
-	cbio->bi_bdev = ldev;
+	bio_set_dev(cbio, ldev);
 	cbio->bi_iter.bi_sector = addr_lb(pbs, ldev_off_pb) + bio_off_lb;
 	/* cbio->bi_end_io = NULL; */
 	/* cbio->bi_private = NULL; */
@@ -2384,7 +2384,7 @@ static bool submit_flush(struct bio_entry *bioe, struct block_device *bdev)
 	if (!bio)
 		return false;
 
-	bio->bi_bdev = bdev;
+	bio_set_dev(bio, bdev);
 	bio_set_op_attrs(bio, REQ_OP_WRITE, REQ_PREFLUSH);
 
 	init_bio_entry(bioe, bio);
@@ -3203,7 +3203,7 @@ void iocore_log_make_request(struct walb_dev *wdev, struct bio *bio)
 		bio_io_error(bio);
 		return;
 	}
-	bio->bi_bdev = wdev->ldev;
+	bio_set_dev(bio, wdev->ldev);
 	generic_make_request(bio);
 }
 

--- a/module/redo.c
+++ b/module/redo.c
@@ -336,7 +336,7 @@ static struct bio_wrapper* create_log_bio_wrapper_for_redo(
 	biow = alloc_bio_wrapper_inc(wdev, GFP_NOIO);
 	if (!biow) { goto error2; }
 
-	bio->bi_bdev = wdev->ldev;
+	bio_set_dev(bio, wdev->ldev);
 	off_pb = get_offset_of_lsid(lsid, wdev->ring_buffer_off, wdev->ring_buffer_size);
 	WLOG_(wdev, "lsid: %" PRIu64 " off_pb: %" PRIu64 "\n", lsid, off_pb);
 	off_lb = addr_lb(pbs, off_pb);
@@ -392,7 +392,7 @@ static bool prepare_data_bio_for_redo(
 	bio = bio_alloc(GFP_NOIO, 1);
 	if (!bio) { return false; }
 
-	bio->bi_bdev = wdev->ddev;
+	bio_set_dev(bio, wdev->ddev);
 	bio->bi_iter.bi_sector = pos;
 	bio_set_op_attrs(bio, REQ_OP_WRITE, 0);
 	bio->bi_end_io = bio_end_io_for_redo;
@@ -429,7 +429,7 @@ static struct bio_wrapper* create_discard_bio_wrapper_for_redo(
 	biow = alloc_bio_wrapper_inc(wdev, GFP_NOIO);
 	if (!biow) { goto error1; }
 
-	bio->bi_bdev = wdev->ddev;
+	bio_set_dev(bio, wdev->ddev);
 	bio->bi_iter.bi_sector = pos;
 	bio->bi_iter.bi_size = len << 9;
 	bio_set_op_attrs(bio, REQ_OP_DISCARD, 0);

--- a/module/sector_io.c
+++ b/module/sector_io.c
@@ -59,7 +59,7 @@ bool sector_io(
 	off = offset_in_page(buf);
 
 	bio_set_op_attrs(bio, op, op_flags);
-	bio->bi_bdev = bdev;
+	bio_set_dev(bio, bdev);
 	bio->bi_iter.bi_sector = addr_lb(pbs, addr);
 	bio_add_page(bio, page, pbs, off);
 


### PR DESCRIPTION
#3 のPRの再PRです。

#3 の de1892d と 85dcafa をマージしましたので、
再度で恐れ入りますが、差し支えなければmasterへマージをお願いします。

結果として、下記2つのコミットになりました。

- 5233189 bugfix: #2: unable to reference part_inc_in_flight() and part_dec_in_flight().
	- #3 の de1892d と 85dcafa をマージしたものです
- 534c3ee reflect the mainliine commit "block: replace bi_bdev with a gendisk pointer and partitions index".
	- 内容は #3 の 039fc33 と同じです
	- 上記マージの際、git rebaseでコミット順を変更したため、ハッシュ値が変わっているのみです